### PR TITLE
Add nasbench dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ requires = [
     'h5py',
     'numpy',
     'ConfigSpace'
+    'pandas',  # missing dependency of nasbench
     'https://github.com/google-research/nasbench/archive/master.zip'
     ]
 


### PR DESCRIPTION
`import tabular_benchmarks` loads also nas_cifar10.py which requires the nasbench module. Therefore it should be a package dependency.