### PR TITLE
Faster benchmark initialization for multiple runs

### DIFF
--- a/tabular_benchmarks/fcnet_benchmark.py
+++ b/tabular_benchmarks/fcnet_benchmark.py
@@ -21,6 +21,13 @@ class FCNetBenchmark(object):
 
         self.rng = np.random.RandomState(seed)
 
+    def reset_tracker(self):
+        # __init__() sans the data loading for multiple runs
+        self.X = []
+        self.y = []
+        self.c = []
+        self.rng = np.random.RandomState(seed)
+
     def get_best_configuration(self):
 
         """

--- a/tabular_benchmarks/nas_cifar10.py
+++ b/tabular_benchmarks/nas_cifar10.py
@@ -11,9 +11,12 @@ VERTICES = 7
 
 class NASCifar10(object):
 
-    def __init__(self, data_dir):
+    def __init__(self, data_dir, multi_fidelity=True):
 
-        self.dataset = api.NASBench(os.path.join(data_dir, 'nasbench_full.tfrecord'))
+        if multi_fidelity:
+            self.dataset = api.NASBench(os.path.join(data_dir, 'nasbench_full.tfrecord'))
+        else:
+            self.dataset = api.NASBench(os.path.join(data_dir, 'nasbench_only108.tfrecord'))
         self.X = []
         self.y_valid = []
         self.y_test = []
@@ -21,6 +24,13 @@ class NASCifar10(object):
 
         self.y_star_valid = 0.04944576819737756  # lowest mean validation error
         self.y_star_test = 0.056824247042338016  # lowest mean test error
+
+    def reset_tracker(self):
+        # __init__() sans the data loading for multiple runs
+        self.X = []
+        self.y_valid = []
+        self.y_test = []
+        self.costs = []
 
     @staticmethod
     def objective_function(self, config):

--- a/tabular_benchmarks/nas_cifar10.py
+++ b/tabular_benchmarks/nas_cifar10.py
@@ -13,7 +13,8 @@ class NASCifar10(object):
 
     def __init__(self, data_dir, multi_fidelity=True):
 
-        if multi_fidelity:
+        self.multi_fidelity = multi_fidelity
+        if self.multi_fidelity:
             self.dataset = api.NASBench(os.path.join(data_dir, 'nasbench_full.tfrecord'))
         else:
             self.dataset = api.NASBench(os.path.join(data_dir, 'nasbench_only108.tfrecord'))
@@ -96,6 +97,9 @@ class NASCifar10(object):
 
 class NASCifar10A(NASCifar10):
     def objective_function(self, config, budget=108):
+        if self.multi_fidelity is False:
+            assert budget == 108
+        
         matrix = np.zeros([VERTICES, VERTICES], dtype=np.int8)
         idx = np.triu_indices(matrix.shape[0], k=1)
         for i in range(VERTICES * (VERTICES - 1) // 2):
@@ -137,6 +141,8 @@ class NASCifar10A(NASCifar10):
 
 class NASCifar10B(NASCifar10):
     def objective_function(self, config, budget=108):
+        if self.multi_fidelity is False:
+            assert budget == 108
 
         bitlist = [0] * (VERTICES * (VERTICES - 1) // 2)
         for i in range(MAX_EDGES):
@@ -184,6 +190,8 @@ class NASCifar10B(NASCifar10):
 
 class NASCifar10C(NASCifar10):
     def objective_function(self, config, budget=108):
+        if self.multi_fidelity is False:
+            assert budget == 108
 
         edge_prob = []
         for i in range(VERTICES * (VERTICES - 1) // 2):


### PR DESCRIPTION
These changes do not alter the current behaviour of the classes.

When scheduling multiple runs, the benchmark needs to be initialized every time. Especially for the full CIFAR benchmark, it eats up a fair bit of time which multiplicatively increases with the number of runs.

Adding a `reset_tracker` function to the class which does the job of `__init__` without the data loading.

Also for the CIFAR, adding an option to specify if it is not a multi-fidelity optimization task and therefore load the lighter dataset (_nasbench_only108.tfrecord_) with the fixed epoch budget evaluations.